### PR TITLE
Update ImageWoof 5 epoch 128 with 73.65 average

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,8 @@ Generally you'll see +/- 1% differences from run to run since it's quite a small
 
 | Size (px) | Epochs | Accuracy | URL | Params | GPUs |
 |--|--|--|--|--|--|
-| 128 | 5 | 55.2 | [link](https://github.com/fastai/fastai/blob/master/examples/train_imagenette.py) | `--epochs 5 --bs 64 --lr 3e-3 --mixup 0 --woof 1` | 2 |
-| 192 | 5 | 60.2 | [link](https://github.com/fastai/fastai/blob/master/examples/train_imagenette.py) | `--epochs 5 --bs 64 --lr 3e-3 --mixup 0 --woof 1 --size 192` | 2 |
+| 128 | 5 | 73.65 | [link](https://github.com/lessw2020/Ranger-Mish-ImageWoof-5) | `--woof 1 --size 128 --bs 64 --mixup 0 --epoch 5 --lr 4e-3 --gpu 0 --opt ranger --mom .95 --sched_type flat_and_anneal --ann_start 0.72  | 1 |
+| 192 | 5 | 60.2 | [link](https://github.com/fastai/fastai/blob/master/examples/train_imagenette.py) | `--epochs 5 --bs 64 --lr 3e-3 --mixup 0 --woof 1 --size 192` | 1 |
 | 256 | 5 | 67.6 | [link](https://github.com/sdoria/SimpleSelfAttention) | `--epochs 5 --bs 64 --lr 3e-3 --mixup 0 --woof 1 --size 256 ` | 1 |
 | 128 | 20 | 78.4 | [link](https://github.com/fastai/fastai/blob/master/examples/train_imagenette.py) | `--epochs 20 --bs 64 --lr 3e-3 --mixup 0 --woof 1 --size 128` | 2 |
 | 192 | 20 | 82.4 | [link](https://github.com/fastai/fastai/blob/master/examples/train_imagenette.py) | `--epochs 20 --bs 64 --lr 3e-3 --mixup 0.2 --woof 1 --size 192` | 4 |


### PR DESCRIPTION
Submitting RangerMish update for ImageWoof 128px, 5 epoch score 73.65 average with 20, 5 epochs run.
I made a github repo for it with a workbook and supporting training script.
https://github.com/lessw2020/Ranger-Mish-ImageWoof-5
