### PR TITLE
[WIP] Inpainting results on ImageWang dataset.

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,10 +142,10 @@ Generally you'll see +/- 1% differences from run to run since it's quite a small
 
 | Size (px) | Epochs | URL | Accuracy | # Runs |
 |--|--|--|--|--|
-|128|5|NA|NA|1|
-|128|20|NA|NA|1|
-|128|80|NA|NA|1|
-|128|200|NA|NA|1|
+|128|5|[Inpainting](https://github.com/JoshVarty/SelfSupervisedLearning/blob/7d292979ae4bbf8422e710b5aeabc5131d0f83a0/01_InpaintingImageWang/03_ImageWang_Leadboard_128.ipynb)|40.87%| 5 |
+|128|20|[Inpainting](https://github.com/JoshVarty/SelfSupervisedLearning/blob/7d292979ae4bbf8422e710b5aeabc5131d0f83a0/01_InpaintingImageWang/03_ImageWang_Leadboard_128.ipynb)|61.15%|3|
+|128|80|[Inpainting](https://github.com/JoshVarty/SelfSupervisedLearning/blob/7d292979ae4bbf8422e710b5aeabc5131d0f83a0/01_InpaintingImageWang/03_ImageWang_Leadboard_128.ipynb)|62.18%|1|
+|128|200|[Inpainting](https://github.com/JoshVarty/SelfSupervisedLearning/blob/7d292979ae4bbf8422e710b5aeabc5131d0f83a0/01_InpaintingImageWang/03_ImageWang_Leadboard_128.ipynb)|62.03%|1|
 |192|5|NA|NA|1|
 |192|20|NA|NA|1|
 |192|80|NA|NA|1|

--- a/README.md
+++ b/README.md
@@ -146,10 +146,10 @@ Generally you'll see +/- 1% differences from run to run since it's quite a small
 |128|20|[Inpainting](https://github.com/JoshVarty/SelfSupervisedLearning/blob/7d292979ae4bbf8422e710b5aeabc5131d0f83a0/01_InpaintingImageWang/03_ImageWang_Leadboard_128.ipynb)|61.15%|3|
 |128|80|[Inpainting](https://github.com/JoshVarty/SelfSupervisedLearning/blob/7d292979ae4bbf8422e710b5aeabc5131d0f83a0/01_InpaintingImageWang/03_ImageWang_Leadboard_128.ipynb)|62.18%|1|
 |128|200|[Inpainting](https://github.com/JoshVarty/SelfSupervisedLearning/blob/7d292979ae4bbf8422e710b5aeabc5131d0f83a0/01_InpaintingImageWang/03_ImageWang_Leadboard_128.ipynb)|62.03%|1|
-|192|5|NA|NA|1|
-|192|20|NA|NA|1|
-|192|80|NA|NA|1|
-|192|200|NA|NA|1|
+|192|5|[Inpainting](https://github.com/JoshVarty/SelfSupervisedLearning/blob/34ab526d39b31f976bc821a4c0924db613c2f7f5/01_InpaintingImageWang/03_ImageWang_Leadboard_192.ipynb)|39.33%|5|
+|192|20|[Inpainting](https://github.com/JoshVarty/SelfSupervisedLearning/blob/34ab526d39b31f976bc821a4c0924db613c2f7f5/01_InpaintingImageWang/03_ImageWang_Leadboard_192.ipynb)|64.62%|3|
+|192|80|[Inpainting](https://github.com/JoshVarty/SelfSupervisedLearning/blob/34ab526d39b31f976bc821a4c0924db613c2f7f5/01_InpaintingImageWang/03_ImageWang_Leadboard_192.ipynb)|66.76%|1|
+|192|200|[Inpainting](https://github.com/JoshVarty/SelfSupervisedLearning/blob/34ab526d39b31f976bc821a4c0924db613c2f7f5/01_InpaintingImageWang/03_ImageWang_Leadboard_192.ipynb)|67.12%|1|
 |256|5|NA|NA|1|
 |256|20|NA|NA|1|
 |256|80|NA|NA|1|


### PR DESCRIPTION
These results are based on self-supervised learning with a pretext task that performs 15 epochs of inpainting and a downstream task that performs image classification on the ImageWang `/val` files.

The entire notebook is self-contained and should only depend on the user having installed `fastai2`

I plan to run the same experiments on the `192` and `256` datasets, but haven't had a chance yet. I should have my results by the end of the week, so we can wait until then to merge if you'd like.