### PR TITLE
Correct ImageWang Inpainting results for 128x128 images

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,14 +140,12 @@ Generally you'll see +/- 1% differences from run to run since it's quite a small
 
 ### Image网 Leaderboard
 
-*NB (Feb 26, 2020): leaderboard results need to be recalculated, since previous version was using a pretrained model by mistake.*
-
 | Size (px) | Epochs | URL | Accuracy | # Runs |
 |--|--|--|--|--|
-|128|5|[Inpainting](https://github.com/JoshVarty/SelfSupervisedLearning/blob/7d292979ae4bbf8422e710b5aeabc5131d0f83a0/01_InpaintingImageWang/03_ImageWang_Leadboard_128.ipynb)|NA| 5 |
-|128|20|[Inpainting](https://github.com/JoshVarty/SelfSupervisedLearning/blob/7d292979ae4bbf8422e710b5aeabc5131d0f83a0/01_InpaintingImageWang/03_ImageWang_Leadboard_128.ipynb)|NA|3|
-|128|80|[Inpainting](https://github.com/JoshVarty/SelfSupervisedLearning/blob/7d292979ae4bbf8422e710b5aeabc5131d0f83a0/01_InpaintingImageWang/03_ImageWang_Leadboard_128.ipynb)|NA|1|
-|128|200|[Inpainting](https://github.com/JoshVarty/SelfSupervisedLearning/blob/7d292979ae4bbf8422e710b5aeabc5131d0f83a0/01_InpaintingImageWang/03_ImageWang_Leadboard_128.ipynb)|NA|1|
+|128|5|[Inpainting](https://github.com/JoshVarty/SelfSupervisedLearning/blob/2e5a68be182b8c741a1bd6c7551bc9515d4b5324/01_InpaintingImageWang/03_ImageWang_Leadboard_128.ipynb)|34.72%| 5,mean |
+|128|20|[Inpainting](https://github.com/JoshVarty/SelfSupervisedLearning/blob/2e5a68be182b8c741a1bd6c7551bc9515d4b5324/01_InpaintingImageWang/03_ImageWang_Leadboard_128.ipynb)|59.02%|3,mean|
+|128|80|[Inpainting](https://github.com/JoshVarty/SelfSupervisedLearning/blob/2e5a68be182b8c741a1bd6c7551bc9515d4b5324/01_InpaintingImageWang/03_ImageWang_Leadboard_128.ipynb)|61.85%|1|
+|128|200|[Inpainting](https://github.com/JoshVarty/SelfSupervisedLearning/blob/2e5a68be182b8c741a1bd6c7551bc9515d4b5324/01_InpaintingImageWang/03_ImageWang_Leadboard_128.ipynb)|60.22%|1|
 |192|5|[ContrastiveLearning](https://github.com/WAMRI-AI/imagewang/blob/d575c7e6d531ec14ec10e545c6e672f87e3d5953/02_ImageWang_ContrastLearning_final_192.ipynb)|64.81%|5,mean|
 |192|20|[ContrastiveLearning](https://github.com/WAMRI-AI/imagewang/blob/d575c7e6d531ec14ec10e545c6e672f87e3d5953/02_ImageWang_ContrastLearning_final_192.ipynb)|68.36%|3,mean|
 |192|80|[ContrastiveLearning](https://github.com/WAMRI-AI/imagewang/blob/d575c7e6d531ec14ec10e545c6e672f87e3d5953/02_ImageWang_ContrastLearning_final_192.ipynb)|68.31%|1|


### PR DESCRIPTION
Add the correct inpainting results for 128x128 images with `pretraining=False`