### PR TITLE
New results with depthwise separable convolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,17 +123,17 @@ Generally you'll see +/- 1% differences from run to run since it's quite a small
 
 | Size (px) | Epochs | URL | Accuracy | # Runs |
 |--|--|--|--|--|
-|128|5|[depthwise(x4, stem+body) etc.](https://github.com/liuyao12/imagenette_experiments/blob/master/Woof_ResNet_separable.ipynb)|81.89%|5, mean|
-|128|20|[depthwise(x4, stem+body) etc.](https://github.com/liuyao12/imagenette_experiments/blob/master/Woof_ResNet_separable.ipynb)|88.77%|5, mean|
-|128|80|[depthwise(x4, stem+body) etc.](https://github.com/liuyao12/imagenette_experiments/blob/master/Woof_ResNet_separable.ipynb)|90.22%|1|
-|128|200|[depthwise(x4, stem+body) etc.](https://github.com/liuyao12/imagenette_experiments/blob/master/Woof_ResNet_separable.ipynb)|90.71%|1|
-|192|5|[depthwise(x4) etc.](https://github.com/liuyao12/imagenette_experiments/blob/master/Woof_ResNet_separable.ipynb)|81.15%|5, mean|
-|192|20|[depthwise(x4) etc.](https://github.com/liuyao12/imagenette_experiments/blob/master/Woof_ResNet_separable.ipynb)|88.37%|5, mean|
-|192|80|[depthwise(x4) etc.](https://github.com/liuyao12/imagenette_experiments/blob/master/Woof_ResNet_separable.ipynb)|89.89%|1|
-|192|200|[depthwise(x4) etc.](https://github.com/liuyao12/imagenette_experiments/blob/master/Woof_ResNet_separable.ipynb)|90.32%|1|
-|256|5|[depthwise(x4) etc.](https://github.com/liuyao12/imagenette_experiments/blob/master/Woof_ResNet_separable.ipynb)|82.33%|5, mean|
+|128|5|[depthwise(x6)](https://github.com/liuyao12/imagenette_experiments/blob/master/Woof_ResNet_separable.ipynb)|76.61%|5, mean|
+|128|20|[depthwise(x4)](https://github.com/liuyao12/imagenette_experiments/blob/master/Woof_ResNet_separable.ipynb)|86.27%|5, mean|
+|128|80|[depthwise(x4)](https://github.com/liuyao12/imagenette_experiments/blob/master/Woof_ResNet_separable.ipynb)|87.83%|1|
+|128|200|[fastai2 train_imagenette.py 2020-01](https://github.com/fastai/imagenette/blob/master/2020-01-train.md)|87.20%|1|
+|192|5|[depthwise(x4)](https://github.com/liuyao12/imagenette_experiments/blob/master/Woof_ResNet_separable.ipynb)|81.15%|5, mean|
+|192|20|[depthwise(x4)](https://github.com/liuyao12/imagenette_experiments/blob/master/Woof_ResNet_separable.ipynb)|88.37%|5, mean|
+|192|80|[depthwise(x2)](https://github.com/liuyao12/imagenette_experiments/blob/master/Woof_ResNet_separable.ipynb)|90.30%|1|
+|192|200|[fastai2 train_imagenette.py 2020-01](https://github.com/fastai/imagenette/blob/master/2020-01-train.md)|89.54%|1|
+|256|5|[Resnet Trick + Mish + Sa + MaxBlurPool](https://github.com/ayasyrev/imagenette_experiments/blob/master/Woof_MaxBlurPool_ResnetTrick_s256bs32.ipynb)|78,84%|5, mean|
 |256|20|[Resnet Trick + Mish + Sa + MaxBlurPool](https://github.com/ayasyrev/imagenette_experiments/blob/master/Woof_MaxBlurPool_ResnetTrick_s256bs32.ipynb)|88,58%|5, mean|
-|256|80|[depthwise(x4) etc.](https://github.com/liuyao12/imagenette_experiments/blob/master/Woof_ResNet_separable.ipynb)|90.93%|1|
+|256|80|[fastai2 train_imagenette.py 2020-01](https://github.com/fastai/imagenette/blob/master/2020-01-train.md)|90.48%|1|
 |256|200|[fastai2 train_imagenette.py 2020-01](https://github.com/fastai/imagenette/blob/master/2020-01-train.md)|90.38%|1|
 
 ----

--- a/README.md
+++ b/README.md
@@ -123,17 +123,17 @@ Generally you'll see +/- 1% differences from run to run since it's quite a small
 
 | Size (px) | Epochs | URL | Accuracy | # Runs |
 |--|--|--|--|--|
-|128|5|[depthwise (x4) etc.](https://github.com/liuyao12/imagenette_experiments/blob/master/Woof_ResNet_separable.ipynb)|81.89%|5, mean|
-|128|20|[depthwise (x4) etc.](https://github.com/liuyao12/imagenette_experiments/blob/master/Woof_ResNet_separable.ipynb)|88.67%|5, mean|
-|128|80|[depthwise (x4) etc.](https://github.com/liuyao12/imagenette_experiments/blob/master/Woof_ResNet_separable.ipynb)|90.22%|1|
-|128|200|[depthwise (x4) etc.](https://github.com/liuyao12/imagenette_experiments/blob/master/Woof_ResNet_separable.ipynb)|90.71%|1|
-|192|5|[depthwise (x4 ~~stem~~) etc.](https://github.com/liuyao12/imagenette_experiments/blob/master/Woof_ResNet_separable.ipynb)|81.15%|5, mean|
-|192|20|[depthwise (x4 ~~stem~~) etc.](https://github.com/liuyao12/imagenette_experiments/blob/master/Woof_ResNet_separable.ipynb)|88.37%|5, mean|
-|192|80|[depthwise (x4 ~~stem~~) etc.](https://github.com/liuyao12/imagenette_experiments/blob/master/Woof_ResNet_separable.ipynb)|89.89%|1|
-|192|200|[depthwise (x4 ~~stem~~) etc.](https://github.com/liuyao12/imagenette_experiments/blob/master/Woof_ResNet_separable.ipynb)|90.32%|1|
-|256|5|[depthwise (x4 ~~stem~~) etc.](https://github.com/liuyao12/imagenette_experiments/blob/master/Woof_ResNet_separable.ipynb)|82.33%|5, mean|
+|128|5|[depthwise(x4, stem+body) etc.](https://github.com/liuyao12/imagenette_experiments/blob/master/Woof_ResNet_separable.ipynb)|81.89%|5, mean|
+|128|20|[depthwise(x4, stem+body) etc.](https://github.com/liuyao12/imagenette_experiments/blob/master/Woof_ResNet_separable.ipynb)|88.77%|5, mean|
+|128|80|[depthwise(x4, stem+body) etc.](https://github.com/liuyao12/imagenette_experiments/blob/master/Woof_ResNet_separable.ipynb)|90.22%|1|
+|128|200|[depthwise(x4, stem+body) etc.](https://github.com/liuyao12/imagenette_experiments/blob/master/Woof_ResNet_separable.ipynb)|90.71%|1|
+|192|5|[depthwise(x4) etc.](https://github.com/liuyao12/imagenette_experiments/blob/master/Woof_ResNet_separable.ipynb)|81.15%|5, mean|
+|192|20|[depthwise(x4) etc.](https://github.com/liuyao12/imagenette_experiments/blob/master/Woof_ResNet_separable.ipynb)|88.37%|5, mean|
+|192|80|[depthwise(x4) etc.](https://github.com/liuyao12/imagenette_experiments/blob/master/Woof_ResNet_separable.ipynb)|89.89%|1|
+|192|200|[depthwise(x4) etc.](https://github.com/liuyao12/imagenette_experiments/blob/master/Woof_ResNet_separable.ipynb)|90.32%|1|
+|256|5|[depthwise(x4) etc.](https://github.com/liuyao12/imagenette_experiments/blob/master/Woof_ResNet_separable.ipynb)|82.33%|5, mean|
 |256|20|[Resnet Trick + Mish + Sa + MaxBlurPool](https://github.com/ayasyrev/imagenette_experiments/blob/master/Woof_MaxBlurPool_ResnetTrick_s256bs32.ipynb)|88,58%|5, mean|
-|256|80|[depthwise (x4 ~~stem~~) etc.](https://github.com/liuyao12/imagenette_experiments/blob/master/Woof_ResNet_separable.ipynb)|90.93%|1|
+|256|80|[depthwise(x4) etc.](https://github.com/liuyao12/imagenette_experiments/blob/master/Woof_ResNet_separable.ipynb)|90.93%|1|
 |256|200|[fastai2 train_imagenette.py 2020-01](https://github.com/fastai/imagenette/blob/master/2020-01-train.md)|90.38%|1|
 
 ----

--- a/README.md
+++ b/README.md
@@ -123,13 +123,13 @@ Generally you'll see +/- 1% differences from run to run since it's quite a small
 
 | Size (px) | Epochs | URL | Accuracy | # Runs |
 |--|--|--|--|--|
-|128|5|[depthwise(x6)](https://github.com/liuyao12/imagenette_experiments/blob/master/Woof_ResNet_separable.ipynb)|76.61%|5, mean|
-|128|20|[depthwise(x4)](https://github.com/liuyao12/imagenette_experiments/blob/master/Woof_ResNet_separable.ipynb)|86.27%|5, mean|
-|128|80|[depthwise(x4)](https://github.com/liuyao12/imagenette_experiments/blob/master/Woof_ResNet_separable.ipynb)|87.83%|1|
+|128|5|[depthwise(x6)](https://github.com/liuyao12/imagenette_experiments/blob/master/ResNet_separable.ipynb)|76.61%|5, mean|
+|128|20|[depthwise(x4)](https://github.com/liuyao12/imagenette_experiments/blob/master/ResNet_separable.ipynb)|86.27%|5, mean|
+|128|80|[depthwise(x4)](https://github.com/liuyao12/imagenette_experiments/blob/master/ResNet_separable.ipynb)|87.83%|1|
 |128|200|[fastai2 train_imagenette.py 2020-01](https://github.com/fastai/imagenette/blob/master/2020-01-train.md)|87.20%|1|
-|192|5|[depthwise(x4)](https://github.com/liuyao12/imagenette_experiments/blob/master/Woof_ResNet_separable.ipynb)|81.15%|5, mean|
-|192|20|[depthwise(x4)](https://github.com/liuyao12/imagenette_experiments/blob/master/Woof_ResNet_separable.ipynb)|88.37%|5, mean|
-|192|80|[depthwise(x2)](https://github.com/liuyao12/imagenette_experiments/blob/master/Woof_ResNet_separable.ipynb)|90.30%|1|
+|192|5|[depthwise(x4)](https://github.com/liuyao12/imagenette_experiments/blob/master/ResNet_separable.ipynb)|81.15%|5, mean|
+|192|20|[depthwise(x4)](https://github.com/liuyao12/imagenette_experiments/blob/master/ResNet_separable.ipynb)|88.37%|5, mean|
+|192|80|[depthwise(x2)](https://github.com/liuyao12/imagenette_experiments/blob/master/ResNet_separable.ipynb)|90.30%|1|
 |192|200|[fastai2 train_imagenette.py 2020-01](https://github.com/fastai/imagenette/blob/master/2020-01-train.md)|89.54%|1|
 |256|5|[Resnet Trick + Mish + Sa + MaxBlurPool](https://github.com/ayasyrev/imagenette_experiments/blob/master/Woof_MaxBlurPool_ResnetTrick_s256bs32.ipynb)|78,84%|5, mean|
 |256|20|[Resnet Trick + Mish + Sa + MaxBlurPool](https://github.com/ayasyrev/imagenette_experiments/blob/master/Woof_MaxBlurPool_ResnetTrick_s256bs32.ipynb)|88,58%|5, mean|

--- a/README.md
+++ b/README.md
@@ -123,17 +123,17 @@ Generally you'll see +/- 1% differences from run to run since it's quite a small
 
 | Size (px) | Epochs | URL | Accuracy | # Runs |
 |--|--|--|--|--|
-|128|5|[fastai2 train_imagenette.py 2020-01 + MaxBlurPool](https://github.com/ducha-aiki/imagewoofv2-fastv2-maxpoolblur/blob/master/fastai2-imagenette-train-maxblurpool.ipynb)|73.37%|5, mean|
-|128|20|[fastai2 train_imagenette.py 2020-01 + MaxBlurPool](https://github.com/ducha-aiki/imagewoofv2-fastv2-maxpoolblur/blob/master/fastai2-imagenette-train-maxblurpool.ipynb)|85.52%|5, mean|
-|128|80|[fastai2 train_imagenette.py 2020-01](https://github.com/fastai/imagenette/blob/master/2020-01-train.md)|87.20%|1|
-|128|200|[fastai2 train_imagenette.py 2020-01](https://github.com/fastai/imagenette/blob/master/2020-01-train.md)|87.20%|1|
-|192|5|[Resnet Trick + Mish + Sa + MaxBlurPool](https://github.com/ayasyrev/imagenette_experiments/blob/master/Woof_MaxBlurPool_ResnetTrick_s192bs64_%208744.ipynb)|77.87%|5, mean|
-|192|20|[Resnet Trick + Mish + Sa + MaxBlurPool](https://github.com/ayasyrev/imagenette_experiments/blob/master/Woof_MaxBlurPool_ResnetTrick_s192bs64_%208744.ipynb)|87.85%|5, mean|
-|192|80|[fastai2 train_imagenette.py 2020-01](https://github.com/fastai/imagenette/blob/master/2020-01-train.md)|89.21%|1|
-|192|200|[fastai2 train_imagenette.py 2020-01](https://github.com/fastai/imagenette/blob/master/2020-01-train.md)|89.54%|1|
-|256|5|[Resnet Trick + Mish + Sa + MaxBlurPool](https://github.com/ayasyrev/imagenette_experiments/blob/master/Woof_MaxBlurPool_ResnetTrick_s256bs32.ipynb)|78,84%|5, mean|
+|128|5|[depthwise (x4) etc.](https://github.com/liuyao12/imagenette_experiments/blob/master/Woof_ResNet_separable.ipynb)|81.89%|5, mean|
+|128|20|[depthwise (x4) etc.](https://github.com/liuyao12/imagenette_experiments/blob/master/Woof_ResNet_separable.ipynb)|88.67%|5, mean|
+|128|80|[depthwise (x4) etc.](https://github.com/liuyao12/imagenette_experiments/blob/master/Woof_ResNet_separable.ipynb)|90.22%|1|
+|128|200|[depthwise (x4) etc.](https://github.com/liuyao12/imagenette_experiments/blob/master/Woof_ResNet_separable.ipynb)|90.71%|1|
+|192|5|[depthwise (x4 ~~stem~~) etc.](https://github.com/liuyao12/imagenette_experiments/blob/master/Woof_ResNet_separable.ipynb)|81.15%|5, mean|
+|192|20|[depthwise (x4 ~~stem~~) etc.](https://github.com/liuyao12/imagenette_experiments/blob/master/Woof_ResNet_separable.ipynb)|88.37%|5, mean|
+|192|80|[depthwise (x4 ~~stem~~) etc.](https://github.com/liuyao12/imagenette_experiments/blob/master/Woof_ResNet_separable.ipynb)|89.89%|1|
+|192|200|[depthwise (x4 ~~stem~~) etc.](https://github.com/liuyao12/imagenette_experiments/blob/master/Woof_ResNet_separable.ipynb)|90.32%|1|
+|256|5|[depthwise (x4 ~~stem~~) etc.](https://github.com/liuyao12/imagenette_experiments/blob/master/Woof_ResNet_separable.ipynb)|82.33%|5, mean|
 |256|20|[Resnet Trick + Mish + Sa + MaxBlurPool](https://github.com/ayasyrev/imagenette_experiments/blob/master/Woof_MaxBlurPool_ResnetTrick_s256bs32.ipynb)|88,58%|5, mean|
-|256|80|[fastai2 train_imagenette.py 2020-01](https://github.com/fastai/imagenette/blob/master/2020-01-train.md)|90.48%|1|
+|256|80|[depthwise (x4 ~~stem~~) etc.](https://github.com/liuyao12/imagenette_experiments/blob/master/Woof_ResNet_separable.ipynb)|90.93%|1|
 |256|200|[fastai2 train_imagenette.py 2020-01](https://github.com/fastai/imagenette/blob/master/2020-01-train.md)|90.38%|1|
 
 ----


### PR DESCRIPTION
Not exhaustive, but could serve as the new baseline.

In particular, 
- depthwise (x4) should be used for "stem" as well, but I got "out of memory". When batch_size is lowered, training is a lot slower, and the result is not as good as it could be.
- stem_size, currently at [3,32,64,64], may need to be optimized for this new design;
- the 4 (sometimes called *depth* or *channel multiplier*) may not be optimal.