### PR TITLE
byol for size=192, epochs 20,80,200

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,9 +146,9 @@ Generally you'll see +/- 1% differences from run to run since it's quite a small
 |128|80|[BYOL](https://github.com/KeremTurgutlu/self_supervised/blob/b3ed998d1819db364b7183defba4a26c30ee0e81/nbs/byol_iwang_128.ipynb)|63.98%|1|
 |128|200|[BYOL](https://github.com/KeremTurgutlu/self_supervised/blob/b3ed998d1819db364b7183defba4a26c30ee0e81/nbs/byol_iwang_128.ipynb)|64.44%|1|
 |192|5|[ContrastiveLearning](https://github.com/WAMRI-AI/imagewang/blob/d575c7e6d531ec14ec10e545c6e672f87e3d5953/02_ImageWang_ContrastLearning_final_192.ipynb)|64.81%|5,mean|
-|192|20|[ContrastiveLearning](https://github.com/WAMRI-AI/imagewang/blob/d575c7e6d531ec14ec10e545c6e672f87e3d5953/02_ImageWang_ContrastLearning_final_192.ipynb)|68.36%|3,mean|
-|192|80|[ContrastiveLearning](https://github.com/WAMRI-AI/imagewang/blob/d575c7e6d531ec14ec10e545c6e672f87e3d5953/02_ImageWang_ContrastLearning_final_192.ipynb)|68.31%|1|
-|192|200|[ContrastiveLearning](https://github.com/WAMRI-AI/imagewang/blob/d575c7e6d531ec14ec10e545c6e672f87e3d5953/02_ImageWang_ContrastLearning_final_192.ipynb)|67.93%|1|
+|192|20|[BYOL](https://github.com/KeremTurgutlu/self_supervised/blob/252269827da41b41091cf0db533b65c0d1312f85/nbs/byol_iwang_192.ipynb)|69.01%|3,mean|
+|192|80|[BYOL](https://github.com/KeremTurgutlu/self_supervised/blob/252269827da41b41091cf0db533b65c0d1312f85/nbs/byol_iwang_192.ipynb)|69.27%|1|
+|192|200|[BYOL](https://github.com/KeremTurgutlu/self_supervised/blob/252269827da41b41091cf0db533b65c0d1312f85/nbs/byol_iwang_192.ipynb)|70.32%|1|
 |256|5|[ContrastiveLearning](https://github.com/WAMRI-AI/imagewang/blob/d575c7e6d531ec14ec10e545c6e672f87e3d5953/03_ImageWang_ContrastLearning_final_224.ipynb)|67.70%|5,mean|
 |256|20|[ContrastiveLearning](https://github.com/WAMRI-AI/imagewang/blob/d575c7e6d531ec14ec10e545c6e672f87e3d5953/03_ImageWang_ContrastLearning_final_224.ipynb)|70.03%|3,mean|
 |256|80|[ContrastiveLearning](https://github.com/WAMRI-AI/imagewang/blob/d575c7e6d531ec14ec10e545c6e672f87e3d5953/03_ImageWang_ContrastLearning_final_224.ipynb)|70.71%|1|


### PR DESCRIPTION
@jph00 New results with BYOL with size 192 for epochs 20,80, and 200.

Although, I am not sure if improvements are significant enough to update the leaderboard at least for the following:

```
20 epochs : 68.36% -> 69.01%

80 epochs: 68.31% -> 69.27%
```