### PR TITLE
New LB entry for Imagewang 256px 80/200 epochs

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,5 +196,5 @@ Size (px) | Epochs | URL | Accuracy | # Runs
 |192|200|[SwAV](https://github.com/KeremTurgutlu/self_supervised/blob/eeab0ae53c47a5c9c66759d9350a66963606cacb/nbs/examples/swav_iwang_192.ipynb)|71.77%|1|
 |256|5|[SwAV](https://github.com/KeremTurgutlu/self_supervised/blob/e84ce745d86aa20963492dbf99a93e5a1d8a12e7/examples/training_swav_iwang.ipynb)|79.56%|5,mean|
 |256|20|[SwAV](https://github.com/KeremTurgutlu/self_supervised/blob/d6c444027369b21d51f3dca66a14027bde79c52e/examples/swav_iwang_224-new.ipynb)|79.2%|3,mean|
-|256|80|[SESEMI](https://github.com/FlyreelAI/sesemi/blob/768d9793be92ebf6b2d370d0be87d107979776b0/FastAI-Imagewang-Results.md)|77.61% &pm; 0.34|5,mean&pm;std|
-|256|200|[SESEMI](https://github.com/FlyreelAI/sesemi/blob/768d9793be92ebf6b2d370d0be87d107979776b0/FastAI-Imagewang-Results.md)|77.79% &pm; 0.38|3,mean&pm;std|
+|256|80|[SESEMI](https://github.com/FlyreelAI/sesemi/blob/e6b5882c258721da087d0f579f6886c35f546aff/FastAI-Imagewang-Results.md)|77.61% &pm; 0.34|5,mean&pm;std|
+|256|200|[SESEMI](https://github.com/FlyreelAI/sesemi/blob/e6b5882c258721da087d0f579f6886c35f546aff/FastAI-Imagewang-Results.md)|77.79% &pm; 0.38|3,mean&pm;std|

--- a/README.md
+++ b/README.md
@@ -196,5 +196,5 @@ Size (px) | Epochs | URL | Accuracy | # Runs
 |192|200|[SwAV](https://github.com/KeremTurgutlu/self_supervised/blob/eeab0ae53c47a5c9c66759d9350a66963606cacb/nbs/examples/swav_iwang_192.ipynb)|71.77%|1|
 |256|5|[SwAV](https://github.com/KeremTurgutlu/self_supervised/blob/e84ce745d86aa20963492dbf99a93e5a1d8a12e7/examples/training_swav_iwang.ipynb)|79.56%|5,mean|
 |256|20|[SwAV](https://github.com/KeremTurgutlu/self_supervised/blob/d6c444027369b21d51f3dca66a14027bde79c52e/examples/swav_iwang_224-new.ipynb)|79.2%|3,mean|
-|256|80|[SwAV](https://github.com/KeremTurgutlu/self_supervised/blob/d6c444027369b21d51f3dca66a14027bde79c52e/examples/swav_iwang_224-new.ipynb)|76.2%|1|
-|256|200|[SwAV](https://github.com/KeremTurgutlu/self_supervised/blob/159a11ba969beebeac41f71453615eb4bc9f9efc/nbs/examples/swav_iwang_224.ipynb)|73.98%|1|
+|256|80|[SESEMI](https://github.com/FlyreelAI/sesemi/blob/768d9793be92ebf6b2d370d0be87d107979776b0/FastAI-Imagewang-Results.md)|77.61% &pm; 0.34|5,mean&pm;std|
+|256|200|[SESEMI](https://github.com/FlyreelAI/sesemi/blob/768d9793be92ebf6b2d370d0be87d107979776b0/FastAI-Imagewang-Results.md)|77.79% &pm; 0.38|3,mean&pm;std|


### PR DESCRIPTION
We use a standard training protocol: vanilla ResNet-50 backbone, conventional data augmentation (random cropping, gamma correction, horizontal flipping, mean-variance normalization), Nesterov SGD optimization, and polynomial learning rate decay with warm-up. We simply add unlabeled data for improved accuracy performance with *self-supervised regularization*.
@jph00 @hamelsmu 